### PR TITLE
Small PR: Add event.preventDefault(); to _onMouseDown

### DIFF
--- a/virtualjoystick.js
+++ b/virtualjoystick.js
@@ -223,6 +223,7 @@ VirtualJoystick.prototype._onMouseUp	= function(event)
 
 VirtualJoystick.prototype._onMouseDown	= function(event)
 {
+	event.preventDefault();
 	var x	= event.clientX;
 	var y	= event.clientY;
 	return this._onDown(x, y);


### PR DESCRIPTION
This is a minor PR that adds event.preventDefault(); to the _onMouseDown function.  While debugging with mouseSupport set to true, whenever I did a drag motion, it would try to highlight any text that was printed on the webpage.  This one line of code fixes that.
