### PR TITLE
setting stick X and Y to base X and Y in _onUp when stationarybase: true

### DIFF
--- a/virtualjoystick.js
+++ b/virtualjoystick.js
@@ -155,6 +155,9 @@ VirtualJoystick.prototype._onUp	= function()
 	
 		this._baseX	= this._baseY	= 0;
 		this._stickX	= this._stickY	= 0;
+	}else{
+		this._stickX	= this._baseX;
+		this._stickY	= this._baseY;
 	}
 }
 

--- a/virtualjoystick.js
+++ b/virtualjoystick.js
@@ -107,6 +107,15 @@ VirtualJoystick.touchScreenAvailable	= function()
 
 VirtualJoystick.prototype.deltaX	= function(){ return this._stickX - this._baseX;	}
 VirtualJoystick.prototype.deltaY	= function(){ return this._stickY - this._baseY;	}
+VirtualJoystick.prototype.angle	= function(){ 
+	var dx = this._stickX - this._baseX;
+	var dy = this._stickY - this._baseY;
+	var theta = Math.atan2(dy, dx);
+	theta *= 180/Math.PI;
+	theta = -theta;
+	theta = (theta > 0 ? theta : (360 + theta));
+	return theta;	
+}
 
 VirtualJoystick.prototype.up	= function(){
 	if( this._pressed === false )	return false;


### PR DESCRIPTION
When using a stationary base, stickX and stickY are not reset to anything in the _onUp function, so deltaX and deltaY keep returning the last value prior to _onUp being called.

Setting stickX = baseX and stickY = baseY when stationarybase is not false (as in my pull request) fixes this.
